### PR TITLE
Disabled SAFESEH for Release

### DIFF
--- a/WinQuake/HandmadeQuake/HandmadeQuake.vcxproj
+++ b/WinQuake/HandmadeQuake/HandmadeQuake.vcxproj
@@ -275,6 +275,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>Winmm.lib;DXGUID.LIB;wsock32.lib;mgllt.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>libc.lib</IgnoreSpecificDefaultLibraries>
+      <ImageHasSafeExceptionHandlers />
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">


### PR DESCRIPTION
The project had /SAFESEH enabled by default for Release and building it would result in LNK2026 error for mgllt.lib.
